### PR TITLE
[feat] トップページと全体レイアウト

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "eslint.workingDirectories": [
+    "./front"
+  ],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {

--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -21,6 +21,7 @@
   },
   "settings": {
     "import/resolver": {
+      "typescript": {},
       "alias": {
         "map": [["@", "./src"]],
         "extensions": [".ts", ".tsx"]

--- a/front/package.json
+++ b/front/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint --dir src",
     "lint:fix": "yarn lint --fix",
-    "format": "prettier --write --ignore-path .gitignore './**/*.{js,jsx,json}'"
+    "format": "prettier --write --ignore-path .gitignore './**/*.{ts,tsx,json}'"
   },
   "dependencies": {
     "next": "14.2.9",
@@ -26,6 +26,7 @@
     "eslint-config-next": "14.2.9",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-alias": "^1.1.2",
+    "eslint-import-resolver-typescript": "^3.6.3",
     "eslint-plugin-import": "^2.30.0",
     "eslint-plugin-tailwindcss": "^3.17.4",
     "eslint-plugin-unused-imports": "^4.1.3",

--- a/front/src/app/(auth)/layout.tsx
+++ b/front/src/app/(auth)/layout.tsx
@@ -1,15 +1,9 @@
-import React from "react";
+import { ReactNode } from "react";
 
 export default function AuthLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
-  return (
-    <div className="flex min-h-screen w-full flex-col ">
-      <header></header>
-      <main className="grow">{children}</main>
-      <footer></footer>
-    </div>
-  );
+  return <div>{children}</div>;
 }

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import React from "react";
+import { ReactNode } from "react";
+import { Footers, Headers } from "@/components/layouts";
 
 export const metadata: Metadata = {
   title: "SPFの怪",
@@ -10,11 +11,17 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <html lang="ja">
-      <body>{children}</body>
+      <body>
+        <div className="flex min-h-screen w-full flex-col ">
+          <Headers />
+          <main className="grow">{children}</main>
+          <Footers />
+        </div>
+      </body>
     </html>
   );
 }

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -1,7 +1,11 @@
+import { GithubButton } from "@/components/ui";
+
 export default function Home() {
   return (
-    <article>
-      <h1>トップページ</h1>
+    <article className="flex min-h-60 w-full items-center justify-center">
+      <section className="m-8 flex w-full max-w-96 items-center justify-center rounded bg-white px-4 py-8 text-center">
+        <GithubButton />
+      </section>
     </article>
   );
 }

--- a/front/src/components/layouts/footers/index.tsx
+++ b/front/src/components/layouts/footers/index.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+export default function Footers() {
+  return (
+    <div className="w-full bg-[#959ea7] text-white">
+      <footer className="flex flex-col gap-4 p-4">
+        <div>
+          <h2 className="text-2xl font-semibold md:text-xl">
+            RUNTEQ(ランテック)
+          </h2>
+        </div>
+        <div>
+          <p className="text-center text-sm underline md:text-start">
+            <Link href="">お問い合わせ</Link>
+          </p>
+        </div>
+        <p className="text-center text-sm md:text-start">© 2024 topi_log</p>
+      </footer>
+    </div>
+  );
+}

--- a/front/src/components/layouts/headerNav/index.tsx
+++ b/front/src/components/layouts/headerNav/index.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { TiArrowSortedDown } from "rocketicons/ti";
+
+export default function HeaderNav() {
+  const auth = false;
+
+  if (!auth) return;
+
+  return (
+    <nav>
+      <ul className="flex items-center justify-center gap-6">
+        <li className="flex items-center justify-center">
+          カリキュラム
+          <TiArrowSortedDown className="icon-black-sm" />
+        </li>
+        <li>就活ボード</li>
+        <li>質問</li>
+        <li>イベント</li>
+        <li>求人</li>
+        <li className="flex items-center justify-center">
+          その他
+          <TiArrowSortedDown className="icon-black-sm" />
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/front/src/components/layouts/headers/index.tsx
+++ b/front/src/components/layouts/headers/index.tsx
@@ -1,0 +1,20 @@
+import HeaderNav from "../headerNav";
+import * as Gimmicks from "@/gimmicks";
+
+export default function Headers() {
+  return (
+    <div className="w-full bg-white p-4">
+      <header className="flex items-center justify-between">
+        <div className="flex items-center justify-center gap-8">
+          <h1 className="text-2xl font-semibold text-runteq-primary">RUNTEQ</h1>
+          <div className="hidden md:block">
+            <HeaderNav />
+          </div>
+        </div>
+        <div>
+          <Gimmicks.Notice />
+        </div>
+      </header>
+    </div>
+  );
+}

--- a/front/src/components/layouts/index.ts
+++ b/front/src/components/layouts/index.ts
@@ -1,0 +1,5 @@
+import Footers from "./footers";
+import HeaderNav from "./headerNav";
+import Headers from "./headers";
+
+export { Headers, Footers, HeaderNav };

--- a/front/src/components/ui/githubButton/index.tsx
+++ b/front/src/components/ui/githubButton/index.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { BsGithub } from "rocketicons/bs";
+
+export default function GithubButton() {
+  const handleClick = () => {
+    // TODO: GitHubログイン処理
+  };
+
+  return (
+    <button
+      onClick={() => handleClick()}
+      className="flex items-center justify-center gap-2 rounded bg-black p-4 font-semibold text-white"
+    >
+      <BsGithub className="icon-white-lg" />
+      <span className="pt-1">GitHubでログイン</span>
+    </button>
+  );
+}

--- a/front/src/components/ui/index.ts
+++ b/front/src/components/ui/index.ts
@@ -1,0 +1,3 @@
+import GithubButton from "./githubButton";
+
+export { GithubButton };

--- a/front/src/gimmicks/index.ts
+++ b/front/src/gimmicks/index.ts
@@ -1,0 +1,3 @@
+import Notice from "./notice";
+
+export { Notice };

--- a/front/src/gimmicks/notice/index.tsx
+++ b/front/src/gimmicks/notice/index.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { BsBell } from "rocketicons/bs";
+
+export default function Notice() {
+  const auth = false;
+
+  if (!auth) return;
+
+  const handleClick = () => {
+    // TODO: 通知ギミック
+  };
+
+  return (
+    <button onClick={() => handleClick()}>
+      <BsBell className="icon-black-lg" />
+    </button>
+  );
+}

--- a/front/tailwind.config.ts
+++ b/front/tailwind.config.ts
@@ -1,3 +1,4 @@
+import icons from "rocketicons/tailwind";
 import type { Config } from "tailwindcss";
 
 const config: Config = {
@@ -15,6 +16,6 @@ const config: Config = {
       },
     },
   },
-  plugins: [],
+  plugins: [icons],
 };
 export default config;

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -17,6 +17,7 @@
         "name": "next"
       }
     ],
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -1129,7 +1129,7 @@ eslint-import-resolver-node@^0.3.6, eslint-import-resolver-node@^0.3.9:
     is-core-module "^2.13.0"
     resolve "^1.22.4"
 
-eslint-import-resolver-typescript@^3.5.2:
+eslint-import-resolver-typescript@^3.5.2, eslint-import-resolver-typescript@^3.6.3:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.3.tgz#bb8e388f6afc0f940ce5d2c5fd4a3d147f038d9e"
   integrity sha512-ud9aw4szY9cCT1EWWdGv1L1XR6hh2PaRWif0j2QjQ0pgTY/69iw+W0Z4qZv5wHahOl8isEr+k/JnyAqNQkLkIA==


### PR DESCRIPTION
# 概要
トップページと全体レイアウトを実装しました。

## 補足
トップページはログイン画面です

## 挙動
認証前
| PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/42f74361861a4fa8d84866556444373c.png" width="360px" /> | <img src="https://i.gyazo.com/519fc68b6314722a9a34023275e04e5e.png" width="150px" />

認証後
| PC | SP |
| --- | --- |
| <img src="https://i.gyazo.com/bf75b28711ff1f68c73310ce3e6fa676.png" width="360px" /> | <img src="https://i.gyazo.com/f48fc37bb7a7f066a82340fb7e374119.png" width="150px" />